### PR TITLE
Reorder coordinate systems

### DIFF
--- a/app/src/main/java/com/nujiak/recce/enums/CoordinateSystem.kt
+++ b/app/src/main/java/com/nujiak/recce/enums/CoordinateSystem.kt
@@ -23,16 +23,16 @@ enum class CoordinateSystem(@StringRes val shortName: Int, @StringRes val fullNa
     MGRS(R.string.mgrs, R.string.mgrs_full),
 
     /**
-     * Kertau 1948
-     */
-    KERTAU(R.string.kertau, R.string.kertau),
-
-    /**
      * World Geodetic System 1984
      *
      * Used in Google Maps
      */
     WGS84(R.string.wgs_84, R.string.wgs_84),
+
+    /**
+     * Kertau 1948
+     */
+    KERTAU(R.string.kertau, R.string.kertau),
 
     /**
      * Ordnance Survey National Grid / British National Grid (BNG)

--- a/app/src/main/java/com/nujiak/recce/enums/CoordinateSystem.kt
+++ b/app/src/main/java/com/nujiak/recce/enums/CoordinateSystem.kt
@@ -1,49 +1,57 @@
 package com.nujiak.recce.enums
 
+import androidx.annotation.StringRes
+import com.nujiak.recce.R
 import java.lang.IllegalArgumentException
 
 /**
  * Coordinate System used by the application
  *
+ * The ordering of the enums affects the ordering of the coordinate system in the app
+ *
  * @property index index of the coordinate system in any collection
  */
-enum class CoordinateSystem(val index: Int) {
+enum class CoordinateSystem(@StringRes val shortName: Int, @StringRes val fullName: Int) {
     /**
      * Universal Traverse Mercator
      */
-    UTM(0),
+    UTM(R.string.utm, R.string.utm_full),
 
     /**
      * Military Grid Reference System
      */
-    MGRS(1),
+    MGRS(R.string.mgrs, R.string.mgrs_full),
 
     /**
      * Kertau 1948
      */
-    KERTAU(2),
+    KERTAU(R.string.kertau, R.string.kertau),
 
     /**
      * World Geodetic System 1984
      *
      * Used in Google Maps
      */
-    WGS84(3),
+    WGS84(R.string.wgs_84, R.string.wgs_84),
 
     /**
      * Ordnance Survey National Grid / British National Grid (BNG)
      */
-    BNG(4),
+    BNG(R.string.bng, R.string.bng_full),
 
     /**
      * Maidenhead Locator System (QTH Locator)
      */
-    QTH(5),
+    QTH(R.string.qth, R.string.qth_full),
 
     ;
 
     companion object {
-        private val map = values().associateBy(CoordinateSystem::index)
+        private val map = values().withIndex().associateBy { it.index }
+        private val indices = values().withIndex().associateBy { it.value }
+
+        val shortNames: List<Int> = values().map(CoordinateSystem::shortName)
+        val fullNames = values().map(CoordinateSystem::fullName)
 
         /**
          * Returns the [CoordinateSystem] at the given index
@@ -52,7 +60,13 @@ enum class CoordinateSystem(val index: Int) {
          * @return
          */
         fun atIndex(index: Int): CoordinateSystem {
-            return map[index] ?: throw IllegalArgumentException("Invalid CoordinateSystem index: $index")
+            return map[index]?.value ?: throw IllegalArgumentException("Invalid CoordinateSystem index: $index")
         }
     }
+
+    /**
+     * The index of the [CoordinateSystem]
+     */
+    val index: Int
+        get() = indices[this]!!.index
 }

--- a/app/src/main/java/com/nujiak/recce/fragments/GpsFragment.kt
+++ b/app/src/main/java/com/nujiak/recce/fragments/GpsFragment.kt
@@ -9,7 +9,6 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import com.nujiak.recce.MainViewModel
-import com.nujiak.recce.R
 import com.nujiak.recce.databinding.FragmentGpsBinding
 import com.nujiak.recce.enums.CoordinateSystem
 import com.nujiak.recce.livedatas.FusedLocationLiveData
@@ -54,7 +53,7 @@ class GpsFragment : Fragment() {
         // Observe for preferences changes
         viewModel.coordinateSystem.observe(viewLifecycleOwner, {
             binding.gpsGridSystem.text =
-                resources.getStringArray(R.array.coordinate_systems)[it.index]
+                resources.getString(CoordinateSystem.shortNames[it.index])
             updateLocationUI()
         })
         viewModel.angleUnit.observe(viewLifecycleOwner, {

--- a/app/src/main/java/com/nujiak/recce/fragments/MapFragment.kt
+++ b/app/src/main/java/com/nujiak/recce/fragments/MapFragment.kt
@@ -487,7 +487,7 @@ class MapFragment :
 
     private fun updateCardGridSystem(coordSys: CoordinateSystem) {
         binding.mapGridSystem.text =
-            resources.getStringArray(R.array.coordinate_systems)[coordSys.index]
+            resources.getString(coordSys.shortName)
     }
 
     private fun onAddPinFromMap(): Boolean {

--- a/app/src/main/java/com/nujiak/recce/fragments/ruler/RulerViewHolder.kt
+++ b/app/src/main/java/com/nujiak/recce/fragments/ruler/RulerViewHolder.kt
@@ -37,7 +37,7 @@ class RulerPinViewHolder private constructor(private val binding: RulerPinItemBi
         binding.rulerPinName.isSelected = true
 
         // Grid System
-        binding.rulerPinGridSystem.text = binding.root.resources.getStringArray(R.array.coordinate_systems)[coordSys.index]
+        binding.rulerPinGridSystem.text = binding.root.resources.getString(coordSys.shortName)
         binding.rulerPinGrid.text = formatAsGrids(location.latitude, location.longitude)
 
         val context = binding.root.context

--- a/app/src/main/java/com/nujiak/recce/fragments/saved/PinViewHolder.kt
+++ b/app/src/main/java/com/nujiak/recce/fragments/saved/PinViewHolder.kt
@@ -52,7 +52,7 @@ class PinViewHolder private constructor(private val binding: PinListItemBinding)
         binding.pinName.text = pin.name
 
         binding.pinGridSystem.text =
-            binding.root.resources.getStringArray(R.array.coordinate_systems)[coordSys.index]
+            binding.root.resources.getString(coordSys.shortName)
 
         binding.pinGrid.text =
             formatAsGrids(pin.latitude, pin.longitude)

--- a/app/src/main/java/com/nujiak/recce/preference/PreferenceFragment.kt
+++ b/app/src/main/java/com/nujiak/recce/preference/PreferenceFragment.kt
@@ -5,6 +5,7 @@ import android.util.TypedValue
 import androidx.core.content.ContextCompat
 import androidx.preference.PreferenceFragmentCompat
 import com.nujiak.recce.R
+import com.nujiak.recce.enums.CoordinateSystem
 
 class PreferenceFragment : PreferenceFragmentCompat() {
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
@@ -16,7 +17,8 @@ class PreferenceFragment : PreferenceFragmentCompat() {
         val color = ContextCompat.getColor(requireContext(), colorRes)
 
         val coordSysPreference = findPreference<IntListPreference>("coordinate_system")
-        coordSysPreference?.let {
+        coordSysPreference?.let { it ->
+            it.entries = CoordinateSystem.fullNames.map(resources::getString).toTypedArray()
             it.entryValues = it.entries.mapIndexed { index, _ -> index.toString() }.toTypedArray()
             it.icon.setTint(color)
         }

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -1,22 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string-array name="coordinate_systems">
-        <item>@string/utm</item>
-        <item>@string/mgrs</item>
-        <item>@string/kertau</item>
-        <item>@string/wgs_84</item>
-        <item>@string/bng</item>
-        <item>@string/qth</item>
-    </string-array>
-    <string-array name="coordinate_systems_full">
-        <item>@string/utm_full</item>
-        <item>@string/mgrs_full</item>
-        <item>@string/kertau</item>
-        <item>@string/wgs_84</item>
-        <item>@string/bng_full</item>
-        <item>@string/qth_full</item>
-    </string-array>
-
     <string-array name="angle_units">
         <item>@string/degrees</item>
         <item>@string/nato_mils</item>

--- a/app/src/main/res/xml/preference.xml
+++ b/app/src/main/res/xml/preference.xml
@@ -4,7 +4,6 @@
     <PreferenceCategory android:title="@string/measurement">
         <com.nujiak.recce.preference.IntListPreference
             app:defaultValue="0"
-            app:entries="@array/coordinate_systems_full"
             app:icon="@drawable/ic_baseline_grid_4x4_24"
             app:key="coordinate_system"
             app:title="@string/coordinate_system"


### PR DESCRIPTION
Old order:
1. `UTM`
2. `MGRS`
3. `Kertau 1948`
4. `WGS 84`
5. `BNG`
6. `QTH`

New order:
1. `UTM`
2. `MGRS`
3. `WGS 84`
4. `Kertau 1948`
5. `BNG`
6. `QTH`